### PR TITLE
fix interference when expressions are json objects

### DIFF
--- a/sql.js
+++ b/sql.js
@@ -8,7 +8,7 @@ const sqlText = (count, chains, expressions) => {
     if (expression === undefined) {
       // if expression is undefined, just skip it
       text += chains[i + 1]
-    } else if (expression && expression._sql) {
+    } else if (expression && expression._sql instanceof SqlContainer) {
       // if expression is a sub `sql` template literal
       const { text: _text, values: _values } = sqlText(
         count,
@@ -26,7 +26,7 @@ const sqlText = (count, chains, expressions) => {
   }
 
   return {
-    _sql: { chains, expressions },
+    _sql: new SqlContainer(chains, expressions),
     text,
     values
   }
@@ -46,6 +46,13 @@ const sql = (chains, ...expressions) => {
   // basic usage
   // sql`...`
   return sqlText(1, chains, expressions)
+}
+
+class SqlContainer {
+  constructor(chains, expressions) {
+    this.chains = chains
+    this.expressions = expressions
+  }
 }
 
 module.exports = sql

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -91,3 +91,12 @@ test('shorthand for node-postgres', async () => {
   const books = await sql(db)`select * from books`
   expect(books).toBe(sampleBooks)
 })
+
+test('json as query parameter', () => {
+  const jsonValue = { _sql: { some: 'data' }, item: 'value' }
+  const query = sql`select obj from movies where obj = ${jsonValue}`
+
+  expect(trimSpaces(query.text)).toBe('select obj from movies where obj = $1')
+  expect(query.values).toHaveLength(1)
+  expect(query.values[0]).toBe(jsonValue)
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,8 +17,14 @@ declare function sql(
 
 declare namespace sql {
   interface QueryConfig {
-    _sql?: { chains: ReadonlyArray<string>; expressions: any[] }
+    _sql?: SqlContainer
     text: string
     values: any[]
   }
+}
+
+declare class SqlContainer {
+  constructor(chains: ReadonlyArray<string>, expressions: any[])
+  readonly chains: ReadonlyArray<string>
+  readonly expressions: any[]
 }


### PR DESCRIPTION
`node-postgres` allows JSON objects as query parameters (https://node-postgres.com/features/types). It can be problematic here if the JSON object contains an `_sql` field:

```js
const jsonValue = { _sql: { some: 'data' }, item: 'value' }
const query = sql`select obj from movies where obj = ${jsonValue}`
```

I suggest encapsulating the `_sql` data in a specific object.

- [X] tests
- [X] typescript definitions